### PR TITLE
integrate EAS into workflows

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -45,12 +45,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
-      - name: Build
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build on EAS
         id: build
-        # Check whether EAS build needs the sha of the commit to build
         run: |
-          eas_build_url=$( echo 'Run EAS build here, ideally with nowait' )
+          eas_build_url=$( eas build --platform android --profile release-candidate --non-interactive --no-wait )
           echo "eas_build_url=$eas_build_url" >> $GITHUB_OUTPUT
 
   comment:

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+env:
+  EAS_PROJECT_URL: 'https://expo.dev/accounts/digidem/projects/example-app'
+
 jobs:
   build:
     name: Build
@@ -59,7 +62,8 @@ jobs:
       - name: Build on EAS
         id: build
         run: |
-          eas_build_url=$( eas build --platform android --profile release-candidate --non-interactive --no-wait )
+          build_id=$( eas build --platform android --profile release-candidate --json --non-interactive --no-wait | jq '.[0].id' --raw-output )
+          eas_build_url="$EAS_PROJECT_URL/builds/$build_id"
           echo "eas_build_url=$eas_build_url" >> $GITHUB_OUTPUT
 
   comment:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - 'release/**'
 
-
 jobs:
   build:
     name: Build
@@ -24,12 +23,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
-      - name: Build
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build on EAS
         id: build
-        # Check whether EAS build needs the sha of the commit to build
         run: |
-          eas_build_url=$( echo 'Run EAS build here, ideally with nowait' )
+          eas_build_url=$( eas build --platform android --profile production --non-interactive --no-wait )
           echo "eas_build_url=$eas_build_url" >> $GITHUB_OUTPUT
 
   comment:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - 'release/**'
 
+env:
+  EAS_PROJECT_URL: "https://expo.dev/accounts/digidem/projects/example-app"
+
 jobs:
   build:
     name: Build
@@ -37,7 +40,8 @@ jobs:
       - name: Build on EAS
         id: build
         run: |
-          eas_build_url=$( eas build --platform android --profile production --non-interactive --no-wait )
+          build_id=$( eas build --platform android --profile production --json --non-interactive --no-wait | jq '.[0].id' --raw-output )
+          eas_build_url="$EAS_PROJECT_URL/builds/$build_id"
           echo "eas_build_url=$eas_build_url" >> $GITHUB_OUTPUT
 
   comment:


### PR DESCRIPTION
Closes #1 

Mostly informed by https://docs.expo.dev/build/building-on-ci/#github-actions

~Still need `RELEASE_BOT_PRIVATE_KEY` defined in the repo as an org secret in order to actually test the workflows once this is merged. Not really sure how to do that (or if I have permissions to)~ EDIT: handled by Gregor