### PR TITLE
create tag as part of release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,9 +77,23 @@ jobs:
         needs: build
 
         steps:
+            - name: Create GitHub App Token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  token: ${{ steps.app-token.outputs.token }}
+
             - name: Parse version
               id: version
               uses: ./.github/parse-version
+
             - name: Tag release
               run: |
                   git config --global user.name 'awana-release-bot[bot]'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,3 +70,19 @@ jobs:
 
               run: |
                   gh pr comment $PR_NUMBER --body "$COMMENT_BODY" --repo "$GITHUB_REPOSITORY"
+
+    tag:
+        name: Create release tag
+        runs-on: ubuntu-latest
+        needs: build
+
+        steps:
+            - name: Parse version
+              id: version
+              uses: ./.github/parse-version
+            - name: Tag release
+              run: |
+                  git config --global user.name 'awana-release-bot[bot]'
+                  git config --global user.email '${{ vars.RELEASE_BOT_USER_ID }}+awana-release-bot[bot]@users.noreply.github.com'
+                  git tag v${{ steps.version.outputs.releaseShort }}
+                  git push origin v${{ steps.version.outputs.releaseShort }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,7 +87,6 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.pull_request.base.sha }}
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Parse version


### PR DESCRIPTION
Towards #4 

Adds a step to create a git tag for the release after triggering a release build