### PR TITLE
add checks for PRs to release branchs

### DIFF
--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -63,5 +63,5 @@ jobs:
               run: exit 1
 
             - name: Assert release version matches RC branch name
-              if: format('rc/{0}', steps.version.outputs.release) != github.head_ref
+              if: format('rc/v{0}', steps.version.outputs.releaseShort) != github.head_ref
               run: exit 1

--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -1,4 +1,4 @@
-name: Check Release Branch
+name: Check PR to Release
 
 on:
     pull_request:

--- a/.github/workflows/check-pr-to-release.yml
+++ b/.github/workflows/check-pr-to-release.yml
@@ -54,6 +54,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Checkout package.json
+              uses: actions/checkout@v4
+              with:
+                  sparse-checkout: |
+                      package.json
+                  sparse-checkout-cone-mode: false
+
             - name: Parse version
               id: version
               uses: ./.github/parse-version

--- a/.github/workflows/check-release-branch.yml
+++ b/.github/workflows/check-release-branch.yml
@@ -39,8 +39,8 @@ jobs:
                     exit 1
                   fi
 
-    check_rc_branch:
-        name: Check RC branch
+    check_pr_branch:
+        name: Check PR branch
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/check-release-branch.yml
+++ b/.github/workflows/check-release-branch.yml
@@ -39,54 +39,29 @@ jobs:
                     exit 1
                   fi
 
-    check_pr_branch:
-        name: Check PR branch
+    check_source_branch:
+        name: Check source branch
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+            - name: Assert source branch is RC branch
+              if: ${{ !startsWith(github.head_ref, 'rc/') }}
+              run: exit 1
 
-            - name: Get branch name of the PR
-              id: pr_branch_name
-              run: |
-                  pr_branch_name=$(git branch --show-current)
-                  echo "result=$PR_BRANCH_NAME" >> $GITHUB_OUTPUT
+    check_release_version:
+        name: Check release version
+        needs: check_source_branch
+        runs-on: ubuntu-latest
 
-            - name: Assert pull request is created from a RC branch
-              env:
-                  PR_BRANCH_NAME: ${{ steps.pr_branch_name.outputs.result }}
-              run: |
-                  set -x
-                  if [ $PR_BRANCH_NAME != rc/* ]; then
-                      echo "Pull request to release branch must come from RC branch"
-                      exit 1
-                  fi
-
+        steps:
             - name: Parse version
               id: version
               uses: ./.github/parse-version
 
             - name: Assert release version is not pre-release
-              env:
-                  RELEASE_VERSION: ${{ steps.version.outputs.releaseVersion }}
-              run: |
-                  set -x
-                  echo $RELEASE_VERSION
-                  if [ $RELEASE_VERSION = *-pre ]; then
-                    echo "Release version cannot be pre-release"
-                    exit 1
-                  fi
+              if: endsWith(steps.version.outputs.releaseVersion, '-pre')
+              run: exit 1
 
             - name: Assert release version matches RC branch name
-              env:
-                  PR_BRANCH_NAME: ${{ steps.pr_branch_name.outputs.result }}
-                  RELEASE_SHORT: ${{ steps.version.outputs.releaseShort }}
-              run: |
-                  set -x
-                  echo $PR_BRANCH_NAME
-                  echo $RELEASE_SHORT
-                  if [ $PR_BRANCH_NAME != "rc/v$RELEASE_SHORT" ]; then
-                      echo "Release version does not match RC branch"
-                      exit 1
-                  fi
+              if: format('rc/{0}', steps.version.outputs.release) != github.head_ref
+              run: exit 1

--- a/.github/workflows/check-release-branch.yml
+++ b/.github/workflows/check-release-branch.yml
@@ -10,7 +10,7 @@ on:
             - 'release/**'
 
 jobs:
-    check_branch:
+    check_release_branch:
         name: No Commits
         runs-on: ubuntu-latest
 
@@ -39,19 +39,54 @@ jobs:
                     exit 1
                   fi
 
-    assert_from_rc_branch:
-        name: Only allow pull request from RC branch
+    check_rc_branch:
+        name: Check RC branch
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
 
+            - name: Get branch name of the PR
+              id: pr_branch_name
+              run: |
+                  pr_branch_name=$(git branch --show-current)
+                  echo "result=$PR_BRANCH_NAME" >> $GITHUB_OUTPUT
+
             - name: Assert pull request is created from a RC branch
+              env:
+                  PR_BRANCH_NAME: ${{ steps.pr_branch_name.outputs.result }}
               run: |
                   set -x
-                  PR_BRANCH_NAME=$(git branch --show-current)
                   if [ $PR_BRANCH_NAME != rc/* ]; then
                       echo "Pull request to release branch must come from RC branch"
+                      exit 1
+                  fi
+
+            - name: Parse version
+              id: version
+              uses: ./.github/parse-version
+
+            - name: Assert release version is not pre-release
+              env:
+                  RELEASE_VERSION: ${{ steps.version.outputs.releaseVersion }}
+              run: |
+                  set -x
+                  echo $RELEASE_VERSION
+                  if [ $RELEASE_VERSION = *-pre ]; then
+                    echo "Release version cannot be pre-release"
+                    exit 1
+                  fi
+
+            - name: Assert release version matches RC branch name
+              env:
+                  PR_BRANCH_NAME: ${{ steps.pr_branch_name.outputs.result }}
+                  RELEASE_SHORT: ${{ steps.version.outputs.releaseShort }}
+              run: |
+                  set -x
+                  echo $PR_BRANCH_NAME
+                  echo $RELEASE_SHORT
+                  if [ $PR_BRANCH_NAME != "rc/v$RELEASE_SHORT" ]; then
+                      echo "Release version does not match RC branch"
                       exit 1
                   fi

--- a/.github/workflows/check-release-branch.yml
+++ b/.github/workflows/check-release-branch.yml
@@ -38,3 +38,20 @@ jobs:
                     echo "Base branch has commits since merge base"
                     exit 1
                   fi
+
+    assert_from_rc_branch:
+        name: Only allow pull request from RC branch
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Assert pull request is created from a RC branch
+              run: |
+                  set -x
+                  PR_BRANCH_NAME=$(git branch --show-current)
+                  if [ $PR_BRANCH_NAME != rc/* ]; then
+                      echo "Pull request to release branch must come from RC branch"
+                      exit 1
+                  fi


### PR DESCRIPTION
Towards #4 

Adds the following checks:

1. Makes sure any PR to a `release/*` branch is an RC branch (i.e. starts with `rc/`)

2. Makes sure the version introduced by the RC PRs:

  - is not a pre-release
  - matches the branch name
 
Still missing:

- [ ] ~check to make sure the version bump is correct~ EDIT: to be done as a follow-up

~Question: should we rename the workflow file? Introducing the job that has these checks makes the name `Check Release Branch` a little unclear to me.~ EDIT: I've renamed the worfklow file to be more explicit (see https://github.com/digidem/release-automations-expo/pull/7/commits/8ca1c89418f82b52cc3e30cbad0f3e9552415ef4)