### PR TITLE
use correct version for release tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,13 +89,16 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token }}
 
-            - name: Parse version
+            # parse-version action doesn't exactly do what we want
+            - name: Extract release version
               id: version
-              uses: ./.github/parse-version
+              run: |
+                  short=$(node -e "const {version} = require('./package.json'); const semver = require('semver'); const parsed = semver.parse(version); console.log(parsed.minor + '.' + parsed.patch);")
+                  echo "release_version_short=$short" >> $GITHUB_OUTPUT
 
             - name: Tag release
               run: |
                   git config --global user.name 'awana-release-bot[bot]'
                   git config --global user.email '${{ vars.RELEASE_BOT_USER_ID }}+awana-release-bot[bot]@users.noreply.github.com'
-                  git tag v${{ steps.version.outputs.releaseShort }}
-                  git push origin v${{ steps.version.outputs.releaseShort }}
+                  git tag v${{ steps.version.outputs.release_version_short }}
+                  git push origin v${{ steps.version.outputs.release_version_short }}


### PR DESCRIPTION
the `parse-versions` action was implemented with the intention of being used when starting a new release cycle, which means that it does version bumps and returns the bumped version in its output, as opposed to the actual version.

In the case of creating a release tag after merging a RC PR, we want to create tag with the same version as what the RC is introducing. At the moment, it's been creating tags that are bumped up a version, so there's an off-by-one error in terms of numbering.