### PR TITLE
chore: fix message displaying RC build trigger comment when release PR is created

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -102,7 +102,7 @@ jobs:
 
                       :warning: Only add bug fixes, copy edits and translation updates during the QA process.
 
-                      :test_tube: Create a new Release Candidate build by commenting on this PR with the `/buildrc` command.
+                      :test_tube: Create a new Release Candidate build by commenting on this PR with the `${{ vars.BUILD_COMMENT_TRIGGER || '/build-rc' }}` command.
 
                       :construction: An initial Release Candidate build will be triggered shortly, and the build URL will be posted here.
 

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -91,7 +91,7 @@ jobs:
 
                       :warning: Only add bug fixes, copy edits and translation updates during the QA process.
 
-                      :test_tube: Create a new Release Candidate build by commenting on this PR with the `/buildrc` command.
+                      :test_tube: Create a new Release Candidate build by commenting on this PR with the `${{ vars.BUILD_COMMENT_TRIGGER || '/build-rc' }}` command.
 
                       :construction: An initial Release Candidate build will be triggered shortly, and the build URL will be posted here.
 


### PR DESCRIPTION
The line of text explaining how to trigger an RC build is misaligned with how the actual workflow that executes that determines the comment to use

https://github.com/digidem/release-automations-expo/blob/99a73e95e7acca8ad82bc0d5d76f479b0c52d234/.github/workflows/build-bot.yml#L13