### PR TITLE
Test Crowdin reminder comment on RC PR

### DIFF
--- a/.github/workflows/crowdin-rc-reminder.yml
+++ b/.github/workflows/crowdin-rc-reminder.yml
@@ -1,26 +1,26 @@
 name: Crowdin Sync Reminder on RC PR Update
 
 on:
-  pull_request:
-    branches:
-      - 'release/**'
-    types: [synchronize]
+    pull_request:
+        branches:
+            - 'release/**'
+        types: [synchronize]
 
 jobs:
-  comment:
-    runs-on: ubuntu-latest
+    comment:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+        steps:
+            - name: Create GitHub App Token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Add Crowdin reminder comment
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr comment $PR_NUMBER --repo "$GITHUB_REPOSITORY" --body ":globe_with_meridians: **Reminder:** Please ensure translations are synced for this release branch in [Crowdin](https://crowdin.com/project/comapeo-mobile)."
+            - name: Add Crowdin reminder comment
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  gh pr comment $PR_NUMBER --repo "$GITHUB_REPOSITORY" --body ":globe_with_meridians: **Reminder:** Please ensure translations are synced for this release branch in [Crowdin](https://crowdin.com/project/comapeo-mobile)."

--- a/.github/workflows/crowdin-rc-reminder.yml
+++ b/.github/workflows/crowdin-rc-reminder.yml
@@ -1,0 +1,26 @@
+name: Crowdin Sync Reminder on RC PR Update
+
+on:
+  pull_request:
+    branches:
+      - 'release/**'
+    types: [synchronize]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Add Crowdin reminder comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment $PR_NUMBER --repo "$GITHUB_REPOSITORY" --body ":globe_with_meridians: **Reminder:** Please ensure translations are synced for this release branch in [Crowdin](https://crowdin.com/project/comapeo-mobile)."

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -105,6 +105,8 @@ jobs:
 
                       :warning: Only add bug fixes, copy edits and translation updates during the QA process.
 
+                      :globe_with_meridians: **Reminder: Please sync this release branch in [Crowdin](https://crowdin.com/project/comapeo-mobile) before triggering a build.**
+
                       :test_tube: Create a new Release Candidate build by commenting on this PR with the `${{ vars.BUILD_COMMENT_TRIGGER || '/build-rc' }}` command.
 
                       :construction: An initial Release Candidate build will be triggered shortly, and the build URL will be posted here.


### PR DESCRIPTION
This PR to test adding a line in the PR body when someone triggers a release branch workflow that reminds them to sync with crowdin.
This PR also adds a test for a workflow that adds a similar comment when someone pushes to a release branch.