### PR TITLE
chore: cherry pick release notes not on initial build

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -54,6 +54,7 @@ jobs:
               uses: ./.github/parse-version
 
             - name: Generate cherry pick release notes
+              if: ${{ github.event_name == 'workflow_call' }}
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   RELEASE_BRANCH: rc/v${{ steps.version.outputs.releaseMinor }}.0


### PR DESCRIPTION
closes #66 